### PR TITLE
pretrained model should set num_classes=1000 before loading state_dict

### DIFF
--- a/senet/se_resnet.py
+++ b/senet/se_resnet.py
@@ -1,3 +1,4 @@
+from os import linesep
 import torch.nn as nn
 from torch.hub import load_state_dict_from_url
 from torchvision.models import ResNet
@@ -114,11 +115,16 @@ def se_resnet50(num_classes=1_000, pretrained=False):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = ResNet(SEBottleneck, [3, 4, 6, 3], num_classes=num_classes)
+    if not pretrained:
+        model = ResNet(SEBottleneck, [3, 4, 6, 3], num_classes=num_classes)
+    else:
+        model = ResNet(SEBottleneck, [3, 4, 6, 3], num_classes=1000)
     model.avgpool = nn.AdaptiveAvgPool2d(1)
     if pretrained:
         model.load_state_dict(load_state_dict_from_url(
             "https://github.com/moskomule/senet.pytorch/releases/download/archive/seresnet50-60a8950a85b2b.pkl"))
+        fc = model.fc
+        model.fc = nn.Linear(fc.in_features, num_classes, bias=True)
     return model
 
 

--- a/senet/se_resnet.py
+++ b/senet/se_resnet.py
@@ -115,16 +115,14 @@ def se_resnet50(num_classes=1_000, pretrained=False):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    if not pretrained:
-        model = ResNet(SEBottleneck, [3, 4, 6, 3], num_classes=num_classes)
-    else:
-        model = ResNet(SEBottleneck, [3, 4, 6, 3], num_classes=1000)
+    model = ResNet(SEBottleneck, [3, 4, 6, 3],
+                   num_classes=(num_classes, 1000)[pretrained])
     model.avgpool = nn.AdaptiveAvgPool2d(1)
     if pretrained:
         model.load_state_dict(load_state_dict_from_url(
             "https://github.com/moskomule/senet.pytorch/releases/download/archive/seresnet50-60a8950a85b2b.pkl"))
-        fc = model.fc
-        model.fc = nn.Linear(fc.in_features, num_classes, bias=True)
+        if num_classes != 1000:
+            model.fc = nn.Linear(model.fc.in_features, num_classes, bias=True)
     return model
 
 


### PR DESCRIPTION
I use senet_resnet50 to train my data with this code:
```
model = model = se_resnet50(num_classes=50,pretrained=True).to(device)
```
this report an Error:
```
Traceback (most recent call last):
  File "test.py", line 2, in <module>
    net = se_resnet50(num_classes=50,pretrained=True)
  File "/home/mix/senet.pytorch/senet/se_resnet.py", line 125, in se_resnet50
    "https://github.com/moskomule/senet.pytorch/releases/download/archive/seresnet50-60a8950a85b2b.pkl"))
  File "/home/mix/anaconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1045, in load_state_dict
    self.__class__.__name__, "\n\t".join(error_msgs)))
RuntimeError: Error(s) in loading state_dict for ResNet:
        size mismatch for fc.weight: copying a param with shape torch.Size([1000, 2048]) from checkpoint, the shape in current model is torch.Size([50, 2048]).
        size mismatch for fc.bias: copying a param with shape torch.Size([1000]) from checkpoint, the shape in current model is torch.Size([50]).
```
finally I found that when pretrained is true num_classes must eqaul 1000 before loading the pkl file